### PR TITLE
refactor(cep): melhorar a implementação do Singleton CepApi

### DIFF
--- a/src/subsistema2/cep/CepApi.java
+++ b/src/subsistema2/cep/CepApi.java
@@ -1,22 +1,54 @@
 package subsistema2.cep;
 
+/**
+ * Singleton que simula a consulta de CEP.
+ * Facade poderá utilizar essa classe para obter cidade e estado.
+ */
 public class CepApi {
 
-	private static CepApi instancia = new CepApi();
+    // Instância única (eager initialization)
+    private static final CepApi instancia = new CepApi();
 
-	private CepApi() {
-		super();
-	}
+    // Construtor privado para impedir instanciamento externo
+    private CepApi() {
+    }
 
-	public static CepApi getInstancia() {
-		return instancia;
-	}
-	
-	public String recuperarCidade(String cep) {
-		return "Araraquara";
-	}
-	
-	public String recuperarEstado(String cep) {
-		return "SP";
-	}
+    // Método público para obter a instância única
+    public static CepApi getInstancia() {
+        return instancia;
+    }
+
+    /**
+     * Recupera a cidade baseada no CEP.
+     * @param cep CEP informado
+     * @return Nome da cidade
+     */
+    public String recuperarCidade(String cep) {
+        // Aqui você poderia simular CEPs diferentes
+        switch (cep) {
+            case "14801788":
+                return "Araraquara";
+            case "01001000":
+                return "São Paulo";
+            default:
+                return "Cidade desconhecida";
+        }
+    }
+
+    /**
+     * Recupera o estado baseada no CEP.
+     * @param cep CEP informado
+     * @return Sigla do estado
+     */
+    public String recuperarEstado(String cep) {
+        // Simulação simples de acordo com o CEP
+        switch (cep) {
+            case "14801788":
+                return "SP";
+            case "01001000":
+                return "SP";
+            default:
+                return "Estado desconhecido";
+        }
+    }
 }


### PR DESCRIPTION
Adicionei comentários Javadoc para explicar a classe e métodos.

Substituí super() desnecessário pelo construtor vazio.

Usei private static final para deixar o Singleton thread-safe e imutável.

Adicionei simulação de múltiplos CEPs, tornando a classe mais próxima de um exemplo realista.